### PR TITLE
Fix compilation errors

### DIFF
--- a/include/helix/order_book.hh
+++ b/include/helix/order_book.hh
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <utility>
 #include <memory>
+#include <string>
 #include <list>
 #include <map>
 

--- a/src/nasdaq/moldudp.cc
+++ b/src/nasdaq/moldudp.cc
@@ -3,6 +3,7 @@
 #include "helix/nasdaq/moldudp_messages.h"
 #include <cassert>
 #include <cstdlib>
+#include <string>
 
 using namespace std;
 


### PR DESCRIPTION
Clang emits compilation errors on `std::string` if the header file is not explicitly included.
