### PR TITLE
nasdaq: don't use auto in C header

### DIFF
--- a/include/helix/nasdaq/nordic_itch_messages.h
+++ b/include/helix/nasdaq/nordic_itch_messages.h
@@ -154,14 +154,14 @@ struct itch_noii {
 static inline uint64_t itch_uatoi(const char *p, size_t len)
 {
     uint64_t ret = 0;
-    auto end = p + len;
+    const char *end = p + len;
     while (p != end) {
         if (*p != ' ')
             break;
         p++;
     }
     while (p != end) {
-        auto ch = *p++;
+        char ch = *p++;
         ret = (ret * 10) + (ch - '0');
     }
     return ret;


### PR DESCRIPTION
Fun:

```
include/helix/nasdaq/nordic_itch_messages.h:157:10: warning: type defaults to ‘int’ in declaration of ‘end’
     auto end = p + len;
          ^
include/helix/nasdaq/nordic_itch_messages.h:157:16: warning: initialization makes integer from pointer without a cast
     auto end = p + len;
                ^
```
