### PR TITLE
Small cleanups

### DIFF
--- a/include/helix/helix.hh
+++ b/include/helix/helix.hh
@@ -62,7 +62,7 @@ public:
     virtual ~session()
     { }
 
-    void* data() const {
+    void* data() {
         return _data;
     }
 

--- a/include/helix/helix.hh
+++ b/include/helix/helix.hh
@@ -38,9 +38,9 @@ struct trade {
     uint64_t    size;
     trade_sign  sign;
 
-    trade(const std::string& symbol_, uint64_t timestamp_,
+    trade(std::string symbol_, uint64_t timestamp_,
           uint64_t price_, uint64_t size_, trade_sign sign_)
-        : symbol{symbol_}
+        : symbol{std::move(symbol_)}
         , timestamp{timestamp_}
         , price{price_}
         , size{size_}

--- a/include/helix/helix.hh
+++ b/include/helix/helix.hh
@@ -55,7 +55,7 @@ using trade_callback = std::function<void(const trade&)>;
 class session {
     void* _data;
 public:
-    session(void* data)
+    explicit session(void* data)
         : _data{data}
     { }
 

--- a/include/helix/nasdaq/itch50_handler.hh
+++ b/include/helix/nasdaq/itch50_handler.hh
@@ -42,7 +42,7 @@ public:
     class unknown_message_type : public std::logic_error {
     public:
         unknown_message_type(std::string cause)
-            : logic_error(cause)
+            : logic_error(std::move(cause))
         { }
     };
 public:

--- a/include/helix/nasdaq/itch50_session.hh
+++ b/include/helix/nasdaq/itch50_session.hh
@@ -28,7 +28,7 @@ public:
 class itch50_protocol : public core::protocol {
     std::string _name;
 public:
-    itch50_protocol(const std::string& name)
+    explicit itch50_protocol(const std::string& name)
         : _name{name}
     { }
     virtual itch50_session* new_session(void *) override;

--- a/include/helix/nasdaq/itch50_session.hh
+++ b/include/helix/nasdaq/itch50_session.hh
@@ -28,8 +28,8 @@ public:
 class itch50_protocol : public core::protocol {
     std::string _name;
 public:
-    explicit itch50_protocol(const std::string& name)
-        : _name{name}
+    explicit itch50_protocol(std::string name)
+        : _name{std::move(name)}
     { }
     virtual itch50_session* new_session(void *) override;
 };

--- a/include/helix/nasdaq/itch50_session.hh
+++ b/include/helix/nasdaq/itch50_session.hh
@@ -18,7 +18,7 @@ private:
     std::shared_ptr<itch50_handler> _handler;
     std::shared_ptr<net::message_parser> _transport_session;
 public:
-    itch50_session(std::shared_ptr<itch50_handler>&&, std::shared_ptr<net::message_parser>&&, void *data);
+    itch50_session(std::shared_ptr<itch50_handler>, std::shared_ptr<net::message_parser>, void *data);
     virtual void subscribe(const std::string& symbol, size_t max_orders) override;
     virtual void register_callback(core::ob_callback process_ob) override;
     virtual void register_callback(core::trade_callback process_trade) override;

--- a/include/helix/nasdaq/nordic_itch_handler.hh
+++ b/include/helix/nasdaq/nordic_itch_handler.hh
@@ -54,7 +54,7 @@ private:
 public:
     class unknown_message_type : public std::logic_error {
     public:
-        unknown_message_type(std::string cause)
+        explicit unknown_message_type(std::string cause)
             : logic_error(cause)
         { }
     };

--- a/include/helix/nasdaq/nordic_itch_handler.hh
+++ b/include/helix/nasdaq/nordic_itch_handler.hh
@@ -55,7 +55,7 @@ public:
     class unknown_message_type : public std::logic_error {
     public:
         explicit unknown_message_type(std::string cause)
-            : logic_error(cause)
+            : logic_error(std::move(cause))
         { }
     };
 public:

--- a/include/helix/nasdaq/nordic_itch_session.hh
+++ b/include/helix/nasdaq/nordic_itch_session.hh
@@ -28,7 +28,7 @@ public:
 class nordic_itch_protocol : public core::protocol {
     std::string _name;
 public:
-    nordic_itch_protocol(const std::string& name)
+    explicit nordic_itch_protocol(const std::string& name)
         : _name{name}
     { }
     virtual nordic_itch_session* new_session(void *) override;

--- a/include/helix/nasdaq/nordic_itch_session.hh
+++ b/include/helix/nasdaq/nordic_itch_session.hh
@@ -18,7 +18,7 @@ private:
     std::shared_ptr<nordic_itch_handler> _handler;
     std::shared_ptr<net::message_parser> _transport_session;
 public:
-    nordic_itch_session(std::shared_ptr<nordic_itch_handler>&&, std::shared_ptr<net::message_parser>&&, void *data);
+    nordic_itch_session(std::shared_ptr<nordic_itch_handler>, std::shared_ptr<net::message_parser>, void *data);
     virtual void subscribe(const std::string& symbol, size_t max_orders) override;
     virtual void register_callback(core::ob_callback process_ob) override;
     virtual void register_callback(core::trade_callback process_trade) override;

--- a/include/helix/nasdaq/nordic_itch_session.hh
+++ b/include/helix/nasdaq/nordic_itch_session.hh
@@ -28,8 +28,8 @@ public:
 class nordic_itch_protocol : public core::protocol {
     std::string _name;
 public:
-    explicit nordic_itch_protocol(const std::string& name)
-        : _name{name}
+    explicit nordic_itch_protocol(std::string name)
+        : _name{std::move(name)}
     { }
     virtual nordic_itch_session* new_session(void *) override;
 };

--- a/include/helix/order_book.hh
+++ b/include/helix/order_book.hh
@@ -109,7 +109,7 @@ private:
 public:
     using iterator = order_set::iterator;
 
-    order_book(const std::string& symbol, uint64_t timestamp, size_t max_orders = 0);
+    order_book(std::string symbol, uint64_t timestamp, size_t max_orders = 0);
     ~order_book();
 
     order_book(const order_book&) = default;

--- a/include/helix/order_book.hh
+++ b/include/helix/order_book.hh
@@ -70,10 +70,6 @@ struct order final {
         , side{side}
         , timestamp{timestamp}
     {}
-
-    order(const order&) = default;
-    order(order&&) = default;
-    order& operator=(const order&) = default;
 };
 
 /// \brief Price level is a time-prioritized list of orders with the same price.
@@ -82,9 +78,6 @@ struct price_level {
         : price(price_)
         , size(0)
     { }
-
-    price_level(const price_level&) = default;
-    price_level& operator=(const price_level&) = default;
 
     uint64_t price;
     uint64_t size;
@@ -110,11 +103,6 @@ public:
     using iterator = order_set::iterator;
 
     order_book(std::string symbol, uint64_t timestamp, size_t max_orders = 0);
-    ~order_book();
-
-    order_book(const order_book&) = default;
-    order_book(order_book&&) = default;
-    order_book& operator=(const order_book&) = default;
 
     const std::string& symbol() const {
         return _symbol;

--- a/include/helix/order_book.hh
+++ b/include/helix/order_book.hh
@@ -124,8 +124,8 @@ public:
         return _state;
     }
 
-    void add(order&& order);
-    void replace(uint64_t order_id, order&& order);
+    void add(order order);
+    void replace(uint64_t order_id, order order);
     void cancel(uint64_t order_id, uint64_t quantity);
     std::pair<uint64_t, side_type> execute(uint64_t order_id, uint64_t quantity);
     void remove(uint64_t order_id);

--- a/include/helix/order_book.hh
+++ b/include/helix/order_book.hh
@@ -78,7 +78,7 @@ struct order final {
 
 /// \brief Price level is a time-prioritized list of orders with the same price.
 struct price_level {
-    price_level(uint64_t price_)
+    explicit price_level(uint64_t price_)
         : price(price_)
         , size(0)
     { }

--- a/src/nasdaq/binaryfile.hh
+++ b/src/nasdaq/binaryfile.hh
@@ -22,7 +22,7 @@ namespace nasdaq {
 class binaryfile_session : public net::message_parser {
     std::shared_ptr<net::message_parser> _parser;
 public:
-    binaryfile_session(std::shared_ptr<net::message_parser> parser);
+    explicit binaryfile_session(std::shared_ptr<net::message_parser> parser);
 
     virtual size_t parse(const net::packet_view& packet) override;
 };

--- a/src/nasdaq/itch50_session.cc
+++ b/src/nasdaq/itch50_session.cc
@@ -13,8 +13,8 @@ namespace helix {
 
 namespace nasdaq {
 
-itch50_session::itch50_session(shared_ptr<itch50_handler>&&handler,
-                             shared_ptr<net::message_parser>&& transport_session,
+itch50_session::itch50_session(shared_ptr<itch50_handler> handler,
+                             shared_ptr<net::message_parser> transport_session,
                              void *data)
     : session{data}
     , _handler{std::move(handler)}

--- a/src/nasdaq/moldudp.hh
+++ b/src/nasdaq/moldudp.hh
@@ -31,7 +31,7 @@ private:
     std::shared_ptr<net::message_parser> _parser;
     uint32_t _seq_num;
 public:
-    moldudp_session(std::shared_ptr<net::message_parser> parser);
+    explicit moldudp_session(std::shared_ptr<net::message_parser> parser);
 
     virtual size_t parse(const net::packet_view& packet) override;
 };

--- a/src/nasdaq/nordic_itch_session.cc
+++ b/src/nasdaq/nordic_itch_session.cc
@@ -14,8 +14,8 @@ namespace helix {
 
 namespace nasdaq {
 
-nordic_itch_session::nordic_itch_session(shared_ptr<nordic_itch_handler>&&handler,
-                                         shared_ptr<net::message_parser>&& transport_session,
+nordic_itch_session::nordic_itch_session(shared_ptr<nordic_itch_handler> handler,
+                                         shared_ptr<net::message_parser> transport_session,
                                          void *data)
     : session{data}
     , _handler{std::move(handler)}

--- a/src/nasdaq/soupfile.cc
+++ b/src/nasdaq/soupfile.cc
@@ -9,7 +9,7 @@ namespace helix {
 namespace nasdaq {
 
 soupfile_session::soupfile_session(shared_ptr<net::message_parser> parser)
-    : _parser{parser}
+    : _parser{std::move(parser)}
 {
 }
 

--- a/src/nasdaq/soupfile.hh
+++ b/src/nasdaq/soupfile.hh
@@ -22,7 +22,7 @@ namespace nasdaq {
 class soupfile_session : public net::message_parser {
     std::shared_ptr<net::message_parser> _parser;
 public:
-    soupfile_session(std::shared_ptr<net::message_parser> parser);
+    explicit soupfile_session(std::shared_ptr<net::message_parser> parser);
 
     virtual size_t parse(const net::packet_view& packet) override;
 };

--- a/src/order_book.cc
+++ b/src/order_book.cc
@@ -10,8 +10,8 @@ namespace helix {
 
 namespace core {
 
-order_book::order_book(const std::string& symbol, uint64_t timestamp, size_t max_orders)
-    : _symbol{symbol}
+order_book::order_book(std::string symbol, uint64_t timestamp, size_t max_orders)
+    : _symbol{std::move(symbol)}
     , _timestamp{timestamp}
     , _state{trading_state::unknown}
 {

--- a/src/order_book.cc
+++ b/src/order_book.cc
@@ -20,7 +20,7 @@ order_book::order_book(std::string symbol, uint64_t timestamp, size_t max_orders
 #endif
 }
 
-void order_book::add(order&& order)
+void order_book::add(order order)
 {
     switch (order.side) {
     case side_type::buy: {
@@ -41,7 +41,7 @@ void order_book::add(order&& order)
     _orders.emplace(std::move(order));
 }
 
-void order_book::replace(uint64_t order_id, order&& order)
+void order_book::replace(uint64_t order_id, order order)
 {
     remove(order_id);
     add(std::move(order));

--- a/src/order_book.cc
+++ b/src/order_book.cc
@@ -20,10 +20,6 @@ order_book::order_book(std::string symbol, uint64_t timestamp, size_t max_orders
 #endif
 }
 
-order_book::~order_book()
-{
-}
-
 void order_book::add(order&& order)
 {
     switch (order.side) {

--- a/tools/helix-svm/helix-svm.cc
+++ b/tools/helix-svm/helix-svm.cc
@@ -76,7 +76,7 @@ class svm_session {
 
 	ostream& _output;
 public:
-	svm_session(ostream& output)
+	explicit svm_session(ostream& output)
 		: _output{output}
 	{ }
 	void process_ob_event(helix_order_book_t ob) {


### PR DESCRIPTION
Change the code to follow two good C++11 idioms consistently:
1. Make unary constructors explicit.
2. When a copy of a parameter is needed, pass it by value and use `std::move()` as appropriate.

In the second case, using `T&&` instead of `T` means the function can't be called with an lvalue. Typically there is no meaningful difference in performance between the two.
