### PR TITLE
Fix Darwin compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ endif(DOXYGEN_FOUND)
 
 find_package(Boost REQUIRED)
 
+find_package(Curses)
+
 find_package(PkgConfig)
 
 pkg_check_modules(LIBUV REQUIRED libuv>=1.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(Boost REQUIRED)
 
 find_package(PkgConfig)
 
-pkg_check_modules(LIBUV REQUIRED libuv>=1.0 ncurses)
+pkg_check_modules(LIBUV REQUIRED libuv>=1.0)
 include_directories(${LIBUV_INCLUDE_DIRS})
 
 include_directories("include")

--- a/include/helix/compat/endian.h
+++ b/include/helix/compat/endian.h
@@ -1,0 +1,29 @@
+#ifndef HELIX_ENDIAN_H
+#define HELIX_ENDIAN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+
+#else
+
+#include <endian.h>
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/nasdaq/binaryfile.cc
+++ b/src/nasdaq/binaryfile.cc
@@ -1,8 +1,8 @@
 #include "binaryfile.hh"
 
-#include <stdexcept>
+#include "helix/compat/endian.h"
 
-#include <endian.h>
+#include <stdexcept>
 
 using namespace std;
 

--- a/src/nasdaq/itch50_handler.cc
+++ b/src/nasdaq/itch50_handler.cc
@@ -1,5 +1,6 @@
 #include "helix/nasdaq/itch50_handler.hh"
 
+#include "helix/compat/endian.h"
 #include "helix/order_book.hh"
 
 #include <unordered_map>
@@ -10,8 +11,6 @@
 #include <cstdio>
 #include <memory>
 #include <string>
-
-#include <endian.h>
 
 using namespace helix::core;
 using namespace std;

--- a/src/parity/moldudp64.cc
+++ b/src/parity/moldudp64.cc
@@ -1,10 +1,10 @@
 #include "moldudp64.hh"
 
 #include "helix/parity/moldudp64_messages.h"
+#include "helix/compat/endian.h"
 #include <cassert>
 #include <cstdlib>
 #include <string>
-#include <endian.h>
 
 using namespace std;
 

--- a/src/parity/pmd_handler.cc
+++ b/src/parity/pmd_handler.cc
@@ -1,10 +1,10 @@
 #include "helix/parity/pmd_handler.hh"
 
+#include "helix/compat/endian.h"
 #include "helix/order_book.hh"
 
 #include <unordered_map>
 #include <stdexcept>
-#include <endian.h>
 #include <cstring>
 #include <cstdint>
 #include <cassert>


### PR DESCRIPTION
- Remove `ncurses` from checked modules as CMake cannot find `ncurses` on Darwin
- Add a compatibility header for endian conversions
