### PR TITLE
order_book.cc: removed redundant calls to find() from lookup_or_create

### DIFF
--- a/src/order_book.cc
+++ b/src/order_book.cc
@@ -126,13 +126,9 @@ void order_book::remove(const order& o, T& levels)
 template<typename T>
 price_level& order_book::lookup_or_create(T& levels, uint64_t price)
 {
-    auto it = levels.find(price);
-    if (it != levels.end()) {
-        return it->second;
-    }
     price_level level{price};
-    levels.emplace(price, level);
-    it = levels.find(price);
+    auto it = levels.emplace(price, level).first;
+
     return it->second;
 }
 


### PR DESCRIPTION
emplace() returns either the iterator to the newly emplaced object or to the object already in the container.