### PR TITLE
order_book: Use 64 bits for quantity

### DIFF
--- a/include/helix/order_book.hh
+++ b/include/helix/order_book.hh
@@ -56,11 +56,11 @@ struct order final {
     price_level* level;
     uint64_t     id;
     uint64_t     price;
-    uint32_t     quantity;
+    uint64_t     quantity;
     side_type    side;
     uint64_t     timestamp;
 
-    order(uint64_t id, uint64_t price, uint32_t quantity, side_type side, uint64_t timestamp)
+    order(uint64_t id, uint64_t price, uint64_t quantity, side_type side, uint64_t timestamp)
         : level{nullptr}
         , id{id}
         , price{price}


### PR DESCRIPTION
Store `quantity` in `order` as an unsigned 64-bit integer. Some of the `order_book` methods already use `uint64_t` for quantity, and Parity PMD, one of the implemented protocols, will use 64 bits for
quantity in Parity 0.7.0.